### PR TITLE
Add ioBroker adapter tests

### DIFF
--- a/.github/workflows/adapter-test.yml
+++ b/.github/workflows/adapter-test.yml
@@ -1,0 +1,47 @@
+name: Test
+
+# Run this job on all pushes and pull requests
+# as well as tags with a semantic version
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      # normal versions
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      # pre-releases
+      - "v[0-9]+.[0-9]+.[0-9]+-**"
+  pull_request: {}
+
+jobs:
+  # Performs quick checks before the expensive test runs
+  check-and-lint:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: ioBroker/testing-action-check@v1
+        with:
+          node-version: '14.x'
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+          lint: true
+
+  # Runs adapter tests on all supported node versions and OSes
+  adapter-tests:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: ioBroker/testing-action-adapter@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          os: ${{ matrix.os }}
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'

--- a/.github/workflows/adapter-test.yml
+++ b/.github/workflows/adapter-test.yml
@@ -43,5 +43,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}
+          build: 'true'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'

--- a/.github/workflows/adapter-test.yml
+++ b/.github/workflows/adapter-test.yml
@@ -43,6 +43,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}
-          build: 'true'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'

--- a/test/integration.js
+++ b/test/integration.js
@@ -2,4 +2,4 @@ const path = require('path');
 const { tests } = require('@iobroker/testing');
 
 // Run integration tests - See https://github.com/ioBroker/testing for a detailed explanation and further options
-tests.integration(path.join(__dirname, '..'), {allowedExitCodes: [6]});
+tests.integration(path.join(__dirname, '..'));

--- a/test/integration.js
+++ b/test/integration.js
@@ -2,4 +2,4 @@ const path = require('path');
 const { tests } = require('@iobroker/testing');
 
 // Run integration tests - See https://github.com/ioBroker/testing for a detailed explanation and further options
-tests.integration(path.join(__dirname, '..'));
+tests.integration(path.join(__dirname, '..'), {allowedExitCodes: [6]});


### PR DESCRIPTION
As Apollon77 mentioned in #20, this script will run all adapter tests on three different OS and three different Node versions.
Release part has been excluded for now.
SOurce: https://github.com/ioBroker/ioBroker.example/blob/master/JavaScript/.github/workflows/test-and-release.yml