### PR TITLE
Let dependabot ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 99
   ignore:
+  - update-types: ["version-update:semver-patch"]
   - dependency-name: "@types/node"
     versions:
     - 14.14.22


### PR DESCRIPTION
Reduce updates and only update minor and major versions
Source: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore

@mobilutz: I think this will reduce the pull requests massively and still makes use of dependabot. What do you think?